### PR TITLE
Move assert to beginning of constructor

### DIFF
--- a/src/main/java/experimental/hashchainpfs/HashChainForwardSecrecy.java
+++ b/src/main/java/experimental/hashchainpfs/HashChainForwardSecrecy.java
@@ -36,8 +36,8 @@ public class HashChainForwardSecrecy implements Serializable {
      * @param currentKey the given key
      */
     public HashChainForwardSecrecy(byte[] currentKey) {
+        assert currentKey.length == NUM_HASH_BYTES; // assure we have correct key length
         this.currentKey = currentKey;
-        assert this.currentKey.length == NUM_HASH_BYTES; // assure we have correct key length
     }
 
     /**


### PR DESCRIPTION
It doesn't really make a difference since it's in the constructor, and capturing an exception means you don't have an object, however it's better practice to assert before any other code is executed.

(Also this PR is to test github's edit thing - press the pencil beside someone else's file and it automatically forks, edits, commits, and PRs the change)
